### PR TITLE
Redirect all the old non-versioned docs to master

### DIFF
--- a/en/advanced_config/advanced_flight_controller_orientation_leveling.html
+++ b/en/advanced_config/advanced_flight_controller_orientation_leveling.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/advanced_flight_controller_orientation_leveling.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/advanced_flight_controller_orientation_leveling.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/advanced_flight_controller_orientation_leveling.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/advanced_flight_controller_orientation_leveling.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/advanced_flight_controller_orientation_leveling.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/advanced_flight_controller_orientation_leveling.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/advanced_flight_controller_orientation_leveling.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/advanced_flight_controller_orientation_leveling.html';</script>
 </body></html>

--- a/en/advanced_config/advanced_mc_position_tuning.html
+++ b/en/advanced_config/advanced_mc_position_tuning.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/advanced_mc_position_tuning.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/advanced_mc_position_tuning.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/advanced_mc_position_tuning.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/advanced_mc_position_tuning.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/advanced_mc_position_tuning.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/advanced_mc_position_tuning.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/advanced_mc_position_tuning.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/advanced_mc_position_tuning.html';</script>
 </body></html>

--- a/en/advanced_config/bootloader_update.html
+++ b/en/advanced_config/bootloader_update.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/bootloader_update.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/bootloader_update.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/bootloader_update.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/bootloader_update.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/bootloader_update.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/bootloader_update.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/bootloader_update.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/bootloader_update.html';</script>
 </body></html>

--- a/en/advanced_config/esc_calibration.html
+++ b/en/advanced_config/esc_calibration.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/esc_calibration.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/esc_calibration.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/esc_calibration.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/esc_calibration.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/esc_calibration.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/esc_calibration.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/esc_calibration.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/esc_calibration.html';</script>
 </body></html>

--- a/en/advanced_config/index.html
+++ b/en/advanced_config/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/index.html';</script>
 </body></html>

--- a/en/advanced_config/land_detector.html
+++ b/en/advanced_config/land_detector.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/land_detector.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/land_detector.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/land_detector.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/land_detector.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/land_detector.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/land_detector.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/land_detector.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/land_detector.html';</script>
 </body></html>

--- a/en/advanced_config/parameter_reference.html
+++ b/en/advanced_config/parameter_reference.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/parameter_reference.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/parameter_reference.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/parameter_reference.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/parameter_reference.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/parameter_reference.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/parameter_reference.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/parameter_reference.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/parameter_reference.html';</script>
 </body></html>

--- a/en/advanced_config/parameters.html
+++ b/en/advanced_config/parameters.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/parameters.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/parameters.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/parameters.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/parameters.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/parameters.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/parameters.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/parameters.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/parameters.html';</script>
 </body></html>

--- a/en/advanced_config/pid_tuning_guide_fixedwing.html
+++ b/en/advanced_config/pid_tuning_guide_fixedwing.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/pid_tuning_guide_fixedwing.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/pid_tuning_guide_fixedwing.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/pid_tuning_guide_fixedwing.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/pid_tuning_guide_fixedwing.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/pid_tuning_guide_fixedwing.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/pid_tuning_guide_fixedwing.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/pid_tuning_guide_fixedwing.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/pid_tuning_guide_fixedwing.html';</script>
 </body></html>

--- a/en/advanced_config/pid_tuning_guide_multicopter.html
+++ b/en/advanced_config/pid_tuning_guide_multicopter.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/pid_tuning_guide_multicopter.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/pid_tuning_guide_multicopter.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/pid_tuning_guide_multicopter.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/pid_tuning_guide_multicopter.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/pid_tuning_guide_multicopter.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/pid_tuning_guide_multicopter.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/pid_tuning_guide_multicopter.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/pid_tuning_guide_multicopter.html';</script>
 </body></html>

--- a/en/advanced_config/racer_setup.html
+++ b/en/advanced_config/racer_setup.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/racer_setup.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/racer_setup.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/racer_setup.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/racer_setup.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/racer_setup.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/racer_setup.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/racer_setup.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/racer_setup.html';</script>
 </body></html>

--- a/en/advanced_config/sensor_thermal_calibration.html
+++ b/en/advanced_config/sensor_thermal_calibration.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/sensor_thermal_calibration.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/sensor_thermal_calibration.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/sensor_thermal_calibration.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/sensor_thermal_calibration.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/sensor_thermal_calibration.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/sensor_thermal_calibration.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/sensor_thermal_calibration.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/sensor_thermal_calibration.html';</script>
 </body></html>

--- a/en/advanced_config/static_pressure_buildup.html
+++ b/en/advanced_config/static_pressure_buildup.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/static_pressure_buildup.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/static_pressure_buildup.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/static_pressure_buildup.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/static_pressure_buildup.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/static_pressure_buildup.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/static_pressure_buildup.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/static_pressure_buildup.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/static_pressure_buildup.html';</script>
 </body></html>

--- a/en/advanced_config/trimming_guide_fixedwing.html
+++ b/en/advanced_config/trimming_guide_fixedwing.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/trimming_guide_fixedwing.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/trimming_guide_fixedwing.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/trimming_guide_fixedwing.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/trimming_guide_fixedwing.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/trimming_guide_fixedwing.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/trimming_guide_fixedwing.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/trimming_guide_fixedwing.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/trimming_guide_fixedwing.html';</script>
 </body></html>

--- a/en/advanced_config/tuning_the_ecl_ekf.html
+++ b/en/advanced_config/tuning_the_ecl_ekf.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/tuning_the_ecl_ekf.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/tuning_the_ecl_ekf.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/tuning_the_ecl_ekf.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/tuning_the_ecl_ekf.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/tuning_the_ecl_ekf.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/tuning_the_ecl_ekf.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/tuning_the_ecl_ekf.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/tuning_the_ecl_ekf.html';</script>
 </body></html>

--- a/en/advanced_config/vtol_without_airspeed_sensor.html
+++ b/en/advanced_config/vtol_without_airspeed_sensor.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_config/vtol_without_airspeed_sensor.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_config/vtol_without_airspeed_sensor.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_config/vtol_without_airspeed_sensor.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_config/vtol_without_airspeed_sensor.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_config/vtol_without_airspeed_sensor.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_config/vtol_without_airspeed_sensor.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_config/vtol_without_airspeed_sensor.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_config/vtol_without_airspeed_sensor.html';</script>
 </body></html>

--- a/en/advanced_features/index.html
+++ b/en/advanced_features/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_features/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_features/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_features/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_features/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_features/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_features/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_features/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_features/index.html';</script>
 </body></html>

--- a/en/advanced_features/precland.html
+++ b/en/advanced_features/precland.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_features/precland.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_features/precland.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_features/precland.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_features/precland.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_features/precland.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_features/precland.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_features/precland.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_features/precland.html';</script>
 </body></html>

--- a/en/advanced_features/rtk-gps.html
+++ b/en/advanced_features/rtk-gps.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_features/rtk-gps.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_features/rtk-gps.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_features/rtk-gps.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_features/rtk-gps.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_features/rtk-gps.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_features/rtk-gps.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_features/rtk-gps.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_features/rtk-gps.html';</script>
 </body></html>

--- a/en/advanced_features/satcom_roadblock.html
+++ b/en/advanced_features/satcom_roadblock.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/advanced_features/satcom_roadblock.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/advanced_features/satcom_roadblock.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/advanced_features/satcom_roadblock.html'>
+<meta http-equiv=refresh content='0; url=/master/en/advanced_features/satcom_roadblock.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/advanced_features/satcom_roadblock.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/advanced_features/satcom_roadblock.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/advanced_features/satcom_roadblock.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/advanced_features/satcom_roadblock.html';</script>
 </body></html>

--- a/en/airframes/airframe_reference.html
+++ b/en/airframes/airframe_reference.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/airframes/airframe_reference.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/airframes/airframe_reference.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/airframes/airframe_reference.html'>
+<meta http-equiv=refresh content='0; url=/master/en/airframes/airframe_reference.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/airframes/airframe_reference.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/airframes/airframe_reference.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/airframes/airframe_reference.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/airframes/airframe_reference.html';</script>
 </body></html>

--- a/en/airframes/index.html
+++ b/en/airframes/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/airframes/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/airframes/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/airframes/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/airframes/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/airframes/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/airframes/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/airframes/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/airframes/index.html';</script>
 </body></html>

--- a/en/assembly/index.html
+++ b/en/assembly/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/assembly/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/assembly/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/assembly/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/assembly/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/assembly/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/assembly/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/assembly/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/assembly/index.html';</script>
 </body></html>

--- a/en/assembly/mount_and_orient_controller.html
+++ b/en/assembly/mount_and_orient_controller.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/assembly/mount_and_orient_controller.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/assembly/mount_and_orient_controller.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/assembly/mount_and_orient_controller.html'>
+<meta http-equiv=refresh content='0; url=/master/en/assembly/mount_and_orient_controller.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/assembly/mount_and_orient_controller.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/assembly/mount_and_orient_controller.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/assembly/mount_and_orient_controller.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/assembly/mount_and_orient_controller.html';</script>
 </body></html>

--- a/en/assembly/quick_start_cube.html
+++ b/en/assembly/quick_start_cube.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/assembly/quick_start_cube.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/assembly/quick_start_cube.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/assembly/quick_start_cube.html'>
+<meta http-equiv=refresh content='0; url=/master/en/assembly/quick_start_cube.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/assembly/quick_start_cube.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/assembly/quick_start_cube.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/assembly/quick_start_cube.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/assembly/quick_start_cube.html';</script>
 </body></html>

--- a/en/assembly/quick_start_pixhawk.html
+++ b/en/assembly/quick_start_pixhawk.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/assembly/quick_start_pixhawk.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/assembly/quick_start_pixhawk.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/assembly/quick_start_pixhawk.html'>
+<meta http-equiv=refresh content='0; url=/master/en/assembly/quick_start_pixhawk.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/assembly/quick_start_pixhawk.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/assembly/quick_start_pixhawk.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/assembly/quick_start_pixhawk.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/assembly/quick_start_pixhawk.html';</script>
 </body></html>

--- a/en/assembly/quick_start_pixhawk4.html
+++ b/en/assembly/quick_start_pixhawk4.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/assembly/quick_start_pixhawk4.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/assembly/quick_start_pixhawk4.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/assembly/quick_start_pixhawk4.html'>
+<meta http-equiv=refresh content='0; url=/master/en/assembly/quick_start_pixhawk4.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/assembly/quick_start_pixhawk4.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/assembly/quick_start_pixhawk4.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/assembly/quick_start_pixhawk4.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/assembly/quick_start_pixhawk4.html';</script>
 </body></html>

--- a/en/assembly/quick_start_pixhawk4_mini.html
+++ b/en/assembly/quick_start_pixhawk4_mini.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/assembly/quick_start_pixhawk4_mini.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/assembly/quick_start_pixhawk4_mini.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/assembly/quick_start_pixhawk4_mini.html'>
+<meta http-equiv=refresh content='0; url=/master/en/assembly/quick_start_pixhawk4_mini.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/assembly/quick_start_pixhawk4_mini.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/assembly/quick_start_pixhawk4_mini.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/assembly/quick_start_pixhawk4_mini.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/assembly/quick_start_pixhawk4_mini.html';</script>
 </body></html>

--- a/en/assembly/quick_start_pixracer.html
+++ b/en/assembly/quick_start_pixracer.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/assembly/quick_start_pixracer.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/assembly/quick_start_pixracer.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/assembly/quick_start_pixracer.html'>
+<meta http-equiv=refresh content='0; url=/master/en/assembly/quick_start_pixracer.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/assembly/quick_start_pixracer.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/assembly/quick_start_pixracer.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/assembly/quick_start_pixracer.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/assembly/quick_start_pixracer.html';</script>
 </body></html>

--- a/en/assembly/vibration_isolation.html
+++ b/en/assembly/vibration_isolation.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/assembly/vibration_isolation.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/assembly/vibration_isolation.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/assembly/vibration_isolation.html'>
+<meta http-equiv=refresh content='0; url=/master/en/assembly/vibration_isolation.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/assembly/vibration_isolation.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/assembly/vibration_isolation.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/assembly/vibration_isolation.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/assembly/vibration_isolation.html';</script>
 </body></html>

--- a/en/complete_vehicles/bebop.html
+++ b/en/complete_vehicles/bebop.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/complete_vehicles/bebop.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/complete_vehicles/bebop.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/complete_vehicles/bebop.html'>
+<meta http-equiv=refresh content='0; url=/master/en/complete_vehicles/bebop.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/complete_vehicles/bebop.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/complete_vehicles/bebop.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/complete_vehicles/bebop.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/complete_vehicles/bebop.html';</script>
 </body></html>

--- a/en/complete_vehicles/betafpv_beta75x.html
+++ b/en/complete_vehicles/betafpv_beta75x.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/complete_vehicles/betafpv_beta75x.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/complete_vehicles/betafpv_beta75x.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/complete_vehicles/betafpv_beta75x.html'>
+<meta http-equiv=refresh content='0; url=/master/en/complete_vehicles/betafpv_beta75x.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/complete_vehicles/betafpv_beta75x.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/complete_vehicles/betafpv_beta75x.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/complete_vehicles/betafpv_beta75x.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/complete_vehicles/betafpv_beta75x.html';</script>
 </body></html>

--- a/en/complete_vehicles/crazyflie2.html
+++ b/en/complete_vehicles/crazyflie2.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/complete_vehicles/crazyflie2.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/complete_vehicles/crazyflie2.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/complete_vehicles/crazyflie2.html'>
+<meta http-equiv=refresh content='0; url=/master/en/complete_vehicles/crazyflie2.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/complete_vehicles/crazyflie2.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/complete_vehicles/crazyflie2.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/complete_vehicles/crazyflie2.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/complete_vehicles/crazyflie2.html';</script>
 </body></html>

--- a/en/complete_vehicles/index.html
+++ b/en/complete_vehicles/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/complete_vehicles/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/complete_vehicles/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/complete_vehicles/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/complete_vehicles/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/complete_vehicles/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/complete_vehicles/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/complete_vehicles/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/complete_vehicles/index.html';</script>
 </body></html>

--- a/en/complete_vehicles/intel_aero.html
+++ b/en/complete_vehicles/intel_aero.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/complete_vehicles/intel_aero.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/complete_vehicles/intel_aero.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/complete_vehicles/intel_aero.html'>
+<meta http-equiv=refresh content='0; url=/master/en/complete_vehicles/intel_aero.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/complete_vehicles/intel_aero.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/complete_vehicles/intel_aero.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/complete_vehicles/intel_aero.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/complete_vehicles/intel_aero.html';</script>
 </body></html>

--- a/en/complete_vehicles/mindracer210.html
+++ b/en/complete_vehicles/mindracer210.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/complete_vehicles/mindracer210.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/complete_vehicles/mindracer210.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/complete_vehicles/mindracer210.html'>
+<meta http-equiv=refresh content='0; url=/master/en/complete_vehicles/mindracer210.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/complete_vehicles/mindracer210.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/complete_vehicles/mindracer210.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/complete_vehicles/mindracer210.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/complete_vehicles/mindracer210.html';</script>
 </body></html>

--- a/en/complete_vehicles/mindracer_BNF_RTF.html
+++ b/en/complete_vehicles/mindracer_BNF_RTF.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/complete_vehicles/mindracer_BNF_RTF.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/complete_vehicles/mindracer_BNF_RTF.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/complete_vehicles/mindracer_BNF_RTF.html'>
+<meta http-equiv=refresh content='0; url=/master/en/complete_vehicles/mindracer_BNF_RTF.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/complete_vehicles/mindracer_BNF_RTF.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/complete_vehicles/mindracer_BNF_RTF.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/complete_vehicles/mindracer_BNF_RTF.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/complete_vehicles/mindracer_BNF_RTF.html';</script>
 </body></html>

--- a/en/complete_vehicles/nanomind110.html
+++ b/en/complete_vehicles/nanomind110.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/complete_vehicles/nanomind110.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/complete_vehicles/nanomind110.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/complete_vehicles/nanomind110.html'>
+<meta http-equiv=refresh content='0; url=/master/en/complete_vehicles/nanomind110.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/complete_vehicles/nanomind110.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/complete_vehicles/nanomind110.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/complete_vehicles/nanomind110.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/complete_vehicles/nanomind110.html';</script>
 </body></html>

--- a/en/computer_vision/collision_prevention.html
+++ b/en/computer_vision/collision_prevention.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/computer_vision/collision_prevention.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/computer_vision/collision_prevention.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/computer_vision/collision_prevention.html'>
+<meta http-equiv=refresh content='0; url=/master/en/computer_vision/collision_prevention.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/computer_vision/collision_prevention.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/computer_vision/collision_prevention.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/computer_vision/collision_prevention.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/computer_vision/collision_prevention.html';</script>
 </body></html>

--- a/en/computer_vision/obstacle_avoidance.html
+++ b/en/computer_vision/obstacle_avoidance.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/computer_vision/obstacle_avoidance.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/computer_vision/obstacle_avoidance.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/computer_vision/obstacle_avoidance.html'>
+<meta http-equiv=refresh content='0; url=/master/en/computer_vision/obstacle_avoidance.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/computer_vision/obstacle_avoidance.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/computer_vision/obstacle_avoidance.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/computer_vision/obstacle_avoidance.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/computer_vision/obstacle_avoidance.html';</script>
 </body></html>

--- a/en/config/accelerometer.html
+++ b/en/config/accelerometer.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/accelerometer.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/accelerometer.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/accelerometer.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/accelerometer.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/accelerometer.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/accelerometer.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/accelerometer.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/accelerometer.html';</script>
 </body></html>

--- a/en/config/airframe.html
+++ b/en/config/airframe.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/airframe.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/airframe.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/airframe.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/airframe.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/airframe.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/airframe.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/airframe.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/airframe.html';</script>
 </body></html>

--- a/en/config/airspeed.html
+++ b/en/config/airspeed.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/airspeed.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/airspeed.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/airspeed.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/airspeed.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/airspeed.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/airspeed.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/airspeed.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/airspeed.html';</script>
 </body></html>

--- a/en/config/battery.html
+++ b/en/config/battery.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/battery.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/battery.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/battery.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/battery.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/battery.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/battery.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/battery.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/battery.html';</script>
 </body></html>

--- a/en/config/compass.html
+++ b/en/config/compass.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/compass.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/compass.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/compass.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/compass.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/compass.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/compass.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/compass.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/compass.html';</script>
 </body></html>

--- a/en/config/firmware.html
+++ b/en/config/firmware.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/firmware.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/firmware.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/firmware.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/firmware.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/firmware.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/firmware.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/firmware.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/firmware.html';</script>
 </body></html>

--- a/en/config/flight_controller_orientation.html
+++ b/en/config/flight_controller_orientation.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/flight_controller_orientation.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/flight_controller_orientation.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/flight_controller_orientation.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/flight_controller_orientation.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/flight_controller_orientation.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/flight_controller_orientation.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/flight_controller_orientation.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/flight_controller_orientation.html';</script>
 </body></html>

--- a/en/config/flight_mode.html
+++ b/en/config/flight_mode.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/flight_mode.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/flight_mode.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/flight_mode.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/flight_mode.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/flight_mode.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/flight_mode.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/flight_mode.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/flight_mode.html';</script>
 </body></html>

--- a/en/config/gyroscope.html
+++ b/en/config/gyroscope.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/gyroscope.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/gyroscope.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/gyroscope.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/gyroscope.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/gyroscope.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/gyroscope.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/gyroscope.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/gyroscope.html';</script>
 </body></html>

--- a/en/config/index.html
+++ b/en/config/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/index.html';</script>
 </body></html>

--- a/en/config/level_horizon_calibration.html
+++ b/en/config/level_horizon_calibration.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/level_horizon_calibration.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/level_horizon_calibration.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/level_horizon_calibration.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/level_horizon_calibration.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/level_horizon_calibration.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/level_horizon_calibration.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/level_horizon_calibration.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/level_horizon_calibration.html';</script>
 </body></html>

--- a/en/config/radio.html
+++ b/en/config/radio.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/radio.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/radio.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/radio.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/radio.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/radio.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/radio.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/radio.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/radio.html';</script>
 </body></html>

--- a/en/config/safety.html
+++ b/en/config/safety.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/safety.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/safety.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/safety.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/safety.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/safety.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/safety.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/safety.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/safety.html';</script>
 </body></html>

--- a/en/config/vtol_quad_configuration.html
+++ b/en/config/vtol_quad_configuration.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config/vtol_quad_configuration.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config/vtol_quad_configuration.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config/vtol_quad_configuration.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config/vtol_quad_configuration.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config/vtol_quad_configuration.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config/vtol_quad_configuration.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config/vtol_quad_configuration.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config/vtol_quad_configuration.html';</script>
 </body></html>

--- a/en/config_fw/index.html
+++ b/en/config_fw/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config_fw/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config_fw/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config_fw/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config_fw/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config_fw/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config_fw/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config_fw/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config_fw/index.html';</script>
 </body></html>

--- a/en/config_fw/pid_tuning_guide_fixedwing.html
+++ b/en/config_fw/pid_tuning_guide_fixedwing.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config_fw/pid_tuning_guide_fixedwing.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config_fw/pid_tuning_guide_fixedwing.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config_fw/pid_tuning_guide_fixedwing.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config_fw/pid_tuning_guide_fixedwing.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config_fw/pid_tuning_guide_fixedwing.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config_fw/pid_tuning_guide_fixedwing.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config_fw/pid_tuning_guide_fixedwing.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config_fw/pid_tuning_guide_fixedwing.html';</script>
 </body></html>

--- a/en/config_fw/trimming_guide_fixedwing.html
+++ b/en/config_fw/trimming_guide_fixedwing.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config_fw/trimming_guide_fixedwing.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config_fw/trimming_guide_fixedwing.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config_fw/trimming_guide_fixedwing.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config_fw/trimming_guide_fixedwing.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config_fw/trimming_guide_fixedwing.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config_fw/trimming_guide_fixedwing.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config_fw/trimming_guide_fixedwing.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config_fw/trimming_guide_fixedwing.html';</script>
 </body></html>

--- a/en/config_mc/advanced_mc_position_tuning.html
+++ b/en/config_mc/advanced_mc_position_tuning.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config_mc/advanced_mc_position_tuning.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config_mc/advanced_mc_position_tuning.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config_mc/advanced_mc_position_tuning.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config_mc/advanced_mc_position_tuning.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config_mc/advanced_mc_position_tuning.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config_mc/advanced_mc_position_tuning.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config_mc/advanced_mc_position_tuning.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config_mc/advanced_mc_position_tuning.html';</script>
 </body></html>

--- a/en/config_mc/index.html
+++ b/en/config_mc/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config_mc/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config_mc/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config_mc/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config_mc/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config_mc/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config_mc/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config_mc/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config_mc/index.html';</script>
 </body></html>

--- a/en/config_mc/pid_tuning_guide_multicopter.html
+++ b/en/config_mc/pid_tuning_guide_multicopter.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config_mc/pid_tuning_guide_multicopter.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config_mc/pid_tuning_guide_multicopter.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config_mc/pid_tuning_guide_multicopter.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config_mc/pid_tuning_guide_multicopter.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config_mc/pid_tuning_guide_multicopter.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config_mc/pid_tuning_guide_multicopter.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config_mc/pid_tuning_guide_multicopter.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config_mc/pid_tuning_guide_multicopter.html';</script>
 </body></html>

--- a/en/config_mc/racer_setup.html
+++ b/en/config_mc/racer_setup.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config_mc/racer_setup.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config_mc/racer_setup.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config_mc/racer_setup.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config_mc/racer_setup.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config_mc/racer_setup.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config_mc/racer_setup.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config_mc/racer_setup.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config_mc/racer_setup.html';</script>
 </body></html>

--- a/en/config_vtol/index.html
+++ b/en/config_vtol/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config_vtol/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config_vtol/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config_vtol/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config_vtol/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config_vtol/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config_vtol/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config_vtol/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config_vtol/index.html';</script>
 </body></html>

--- a/en/config_vtol/vtol_back_transition_tuning.html
+++ b/en/config_vtol/vtol_back_transition_tuning.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config_vtol/vtol_back_transition_tuning.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config_vtol/vtol_back_transition_tuning.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config_vtol/vtol_back_transition_tuning.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config_vtol/vtol_back_transition_tuning.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config_vtol/vtol_back_transition_tuning.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config_vtol/vtol_back_transition_tuning.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config_vtol/vtol_back_transition_tuning.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config_vtol/vtol_back_transition_tuning.html';</script>
 </body></html>

--- a/en/config_vtol/vtol_quad_configuration.html
+++ b/en/config_vtol/vtol_quad_configuration.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config_vtol/vtol_quad_configuration.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config_vtol/vtol_quad_configuration.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config_vtol/vtol_quad_configuration.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config_vtol/vtol_quad_configuration.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config_vtol/vtol_quad_configuration.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config_vtol/vtol_quad_configuration.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config_vtol/vtol_quad_configuration.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config_vtol/vtol_quad_configuration.html';</script>
 </body></html>

--- a/en/config_vtol/vtol_weathervane.html
+++ b/en/config_vtol/vtol_weathervane.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config_vtol/vtol_weathervane.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config_vtol/vtol_weathervane.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config_vtol/vtol_weathervane.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config_vtol/vtol_weathervane.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config_vtol/vtol_weathervane.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config_vtol/vtol_weathervane.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config_vtol/vtol_weathervane.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config_vtol/vtol_weathervane.html';</script>
 </body></html>

--- a/en/config_vtol/vtol_without_airspeed_sensor.html
+++ b/en/config_vtol/vtol_without_airspeed_sensor.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/config_vtol/vtol_without_airspeed_sensor.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/config_vtol/vtol_without_airspeed_sensor.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/config_vtol/vtol_without_airspeed_sensor.html'>
+<meta http-equiv=refresh content='0; url=/master/en/config_vtol/vtol_without_airspeed_sensor.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/config_vtol/vtol_without_airspeed_sensor.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/config_vtol/vtol_without_airspeed_sensor.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/config_vtol/vtol_without_airspeed_sensor.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/config_vtol/vtol_without_airspeed_sensor.html';</script>
 </body></html>

--- a/en/development/development.html
+++ b/en/development/development.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/development/development.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/development/development.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/development/development.html'>
+<meta http-equiv=refresh content='0; url=/master/en/development/development.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/development/development.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/development/development.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/development/development.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/development/development.html';</script>
 </body></html>

--- a/en/flight_controller/HKPilot32.html
+++ b/en/flight_controller/HKPilot32.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/HKPilot32.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/HKPilot32.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/HKPilot32.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/HKPilot32.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/HKPilot32.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/HKPilot32.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/HKPilot32.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/HKPilot32.html';</script>
 </body></html>

--- a/en/flight_controller/auav_x2.html
+++ b/en/flight_controller/auav_x2.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/auav_x2.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/auav_x2.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/auav_x2.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/auav_x2.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/auav_x2.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/auav_x2.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/auav_x2.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/auav_x2.html';</script>
 </body></html>

--- a/en/flight_controller/beaglebone_blue.html
+++ b/en/flight_controller/beaglebone_blue.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/beaglebone_blue.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/beaglebone_blue.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/beaglebone_blue.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/beaglebone_blue.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/beaglebone_blue.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/beaglebone_blue.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/beaglebone_blue.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/beaglebone_blue.html';</script>
 </body></html>

--- a/en/flight_controller/bebop.html
+++ b/en/flight_controller/bebop.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/bebop.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/bebop.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/bebop.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/bebop.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/bebop.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/bebop.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/bebop.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/bebop.html';</script>
 </body></html>

--- a/en/flight_controller/betafpv_beta75x.html
+++ b/en/flight_controller/betafpv_beta75x.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/betafpv_beta75x.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/betafpv_beta75x.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/betafpv_beta75x.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/betafpv_beta75x.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/betafpv_beta75x.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/betafpv_beta75x.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/betafpv_beta75x.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/betafpv_beta75x.html';</script>
 </body></html>

--- a/en/flight_controller/complete_vehicles.html
+++ b/en/flight_controller/complete_vehicles.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/complete_vehicles.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/complete_vehicles.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/complete_vehicles.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/complete_vehicles.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/complete_vehicles.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/complete_vehicles.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/complete_vehicles.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/complete_vehicles.html';</script>
 </body></html>

--- a/en/flight_controller/crazyflie2.html
+++ b/en/flight_controller/crazyflie2.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/crazyflie2.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/crazyflie2.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/crazyflie2.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/crazyflie2.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/crazyflie2.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/crazyflie2.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/crazyflie2.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/crazyflie2.html';</script>
 </body></html>

--- a/en/flight_controller/dropix.html
+++ b/en/flight_controller/dropix.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/dropix.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/dropix.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/dropix.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/dropix.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/dropix.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/dropix.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/dropix.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/dropix.html';</script>
 </body></html>

--- a/en/flight_controller/index.html
+++ b/en/flight_controller/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/index.html';</script>
 </body></html>

--- a/en/flight_controller/intel_aero.html
+++ b/en/flight_controller/intel_aero.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/intel_aero.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/intel_aero.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/intel_aero.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/intel_aero.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/intel_aero.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/intel_aero.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/intel_aero.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/intel_aero.html';</script>
 </body></html>

--- a/en/flight_controller/mind_series.html
+++ b/en/flight_controller/mind_series.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/mind_series.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/mind_series.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/mind_series.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/mind_series.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/mind_series.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/mind_series.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/mind_series.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/mind_series.html';</script>
 </body></html>

--- a/en/flight_controller/mindpx.html
+++ b/en/flight_controller/mindpx.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/mindpx.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/mindpx.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/mindpx.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/mindpx.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/mindpx.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/mindpx.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/mindpx.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/mindpx.html';</script>
 </body></html>

--- a/en/flight_controller/mindracer.html
+++ b/en/flight_controller/mindracer.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/mindracer.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/mindracer.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/mindracer.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/mindracer.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/mindracer.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/mindracer.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/mindracer.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/mindracer.html';</script>
 </body></html>

--- a/en/flight_controller/mindracer210.html
+++ b/en/flight_controller/mindracer210.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/mindracer210.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/mindracer210.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/mindracer210.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/mindracer210.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/mindracer210.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/mindracer210.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/mindracer210.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/mindracer210.html';</script>
 </body></html>

--- a/en/flight_controller/mindracer_BNF_RTF.html
+++ b/en/flight_controller/mindracer_BNF_RTF.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/mindracer_BNF_RTF.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/mindracer_BNF_RTF.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/mindracer_BNF_RTF.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/mindracer_BNF_RTF.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/mindracer_BNF_RTF.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/mindracer_BNF_RTF.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/mindracer_BNF_RTF.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/mindracer_BNF_RTF.html';</script>
 </body></html>

--- a/en/flight_controller/mro_pixhawk.html
+++ b/en/flight_controller/mro_pixhawk.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/mro_pixhawk.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/mro_pixhawk.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/mro_pixhawk.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/mro_pixhawk.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/mro_pixhawk.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/mro_pixhawk.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/mro_pixhawk.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/mro_pixhawk.html';</script>
 </body></html>

--- a/en/flight_controller/mro_x2.1.html
+++ b/en/flight_controller/mro_x2.1.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/mro_x2.1.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/mro_x2.1.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/mro_x2.1.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/mro_x2.1.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/mro_x2.1.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/mro_x2.1.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/mro_x2.1.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/mro_x2.1.html';</script>
 </body></html>

--- a/en/flight_controller/nanomind110.html
+++ b/en/flight_controller/nanomind110.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/nanomind110.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/nanomind110.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/nanomind110.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/nanomind110.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/nanomind110.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/nanomind110.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/nanomind110.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/nanomind110.html';</script>
 </body></html>

--- a/en/flight_controller/ocpoc_zynq.html
+++ b/en/flight_controller/ocpoc_zynq.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/ocpoc_zynq.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/ocpoc_zynq.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/ocpoc_zynq.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/ocpoc_zynq.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/ocpoc_zynq.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/ocpoc_zynq.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/ocpoc_zynq.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/ocpoc_zynq.html';</script>
 </body></html>

--- a/en/flight_controller/omnibus_f4_sd.html
+++ b/en/flight_controller/omnibus_f4_sd.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/omnibus_f4_sd.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/omnibus_f4_sd.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/omnibus_f4_sd.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/omnibus_f4_sd.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/omnibus_f4_sd.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/omnibus_f4_sd.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/omnibus_f4_sd.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/omnibus_f4_sd.html';</script>
 </body></html>

--- a/en/flight_controller/pixfalcon.html
+++ b/en/flight_controller/pixfalcon.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/pixfalcon.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/pixfalcon.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/pixfalcon.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/pixfalcon.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/pixfalcon.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/pixfalcon.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/pixfalcon.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/pixfalcon.html';</script>
 </body></html>

--- a/en/flight_controller/pixhack_v3.html
+++ b/en/flight_controller/pixhack_v3.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/pixhack_v3.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/pixhack_v3.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/pixhack_v3.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/pixhack_v3.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/pixhack_v3.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/pixhack_v3.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/pixhack_v3.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/pixhack_v3.html';</script>
 </body></html>

--- a/en/flight_controller/pixhack_v5.html
+++ b/en/flight_controller/pixhack_v5.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/pixhack_v5.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/pixhack_v5.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/pixhack_v5.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/pixhack_v5.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/pixhack_v5.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/pixhack_v5.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/pixhack_v5.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/pixhack_v5.html';</script>
 </body></html>

--- a/en/flight_controller/pixhawk-2.html
+++ b/en/flight_controller/pixhawk-2.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/pixhawk-2.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/pixhawk-2.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/pixhawk-2.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/pixhawk-2.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/pixhawk-2.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/pixhawk-2.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/pixhawk-2.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/pixhawk-2.html';</script>
 </body></html>

--- a/en/flight_controller/pixhawk.html
+++ b/en/flight_controller/pixhawk.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/pixhawk.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/pixhawk.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/pixhawk.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/pixhawk.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/pixhawk.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/pixhawk.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/pixhawk.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/pixhawk.html';</script>
 </body></html>

--- a/en/flight_controller/pixhawk3_pro.html
+++ b/en/flight_controller/pixhawk3_pro.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/pixhawk3_pro.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/pixhawk3_pro.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/pixhawk3_pro.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/pixhawk3_pro.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/pixhawk3_pro.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/pixhawk3_pro.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/pixhawk3_pro.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/pixhawk3_pro.html';</script>
 </body></html>

--- a/en/flight_controller/pixhawk4.html
+++ b/en/flight_controller/pixhawk4.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/pixhawk4.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/pixhawk4.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/pixhawk4.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/pixhawk4.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/pixhawk4.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/pixhawk4.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/pixhawk4.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/pixhawk4.html';</script>
 </body></html>

--- a/en/flight_controller/pixhawk4_mini.html
+++ b/en/flight_controller/pixhawk4_mini.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/pixhawk4_mini.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/pixhawk4_mini.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/pixhawk4_mini.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/pixhawk4_mini.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/pixhawk4_mini.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/pixhawk4_mini.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/pixhawk4_mini.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/pixhawk4_mini.html';</script>
 </body></html>

--- a/en/flight_controller/pixhawk_mini.html
+++ b/en/flight_controller/pixhawk_mini.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/pixhawk_mini.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/pixhawk_mini.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/pixhawk_mini.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/pixhawk_mini.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/pixhawk_mini.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/pixhawk_mini.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/pixhawk_mini.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/pixhawk_mini.html';</script>
 </body></html>

--- a/en/flight_controller/pixhawk_series.html
+++ b/en/flight_controller/pixhawk_series.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/pixhawk_series.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/pixhawk_series.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/pixhawk_series.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/pixhawk_series.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/pixhawk_series.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/pixhawk_series.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/pixhawk_series.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/pixhawk_series.html';</script>
 </body></html>

--- a/en/flight_controller/pixracer.html
+++ b/en/flight_controller/pixracer.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/pixracer.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/pixracer.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/pixracer.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/pixracer.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/pixracer.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/pixracer.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/pixracer.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/pixracer.html';</script>
 </body></html>

--- a/en/flight_controller/raspberry_pi_navio2.html
+++ b/en/flight_controller/raspberry_pi_navio2.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/raspberry_pi_navio2.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/raspberry_pi_navio2.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/raspberry_pi_navio2.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/raspberry_pi_navio2.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/raspberry_pi_navio2.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/raspberry_pi_navio2.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/raspberry_pi_navio2.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/raspberry_pi_navio2.html';</script>
 </body></html>

--- a/en/flight_controller/silicon_errata.html
+++ b/en/flight_controller/silicon_errata.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/silicon_errata.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/silicon_errata.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/silicon_errata.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/silicon_errata.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/silicon_errata.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/silicon_errata.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/silicon_errata.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/silicon_errata.html';</script>
 </body></html>

--- a/en/flight_controller/snapdragon_flight.html
+++ b/en/flight_controller/snapdragon_flight.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/snapdragon_flight.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/snapdragon_flight.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/snapdragon_flight.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/snapdragon_flight.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/snapdragon_flight.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/snapdragon_flight.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/snapdragon_flight.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/snapdragon_flight.html';</script>
 </body></html>

--- a/en/flight_controller/snapdragon_flight_advanced.html
+++ b/en/flight_controller/snapdragon_flight_advanced.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/snapdragon_flight_advanced.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/snapdragon_flight_advanced.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/snapdragon_flight_advanced.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/snapdragon_flight_advanced.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/snapdragon_flight_advanced.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/snapdragon_flight_advanced.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/snapdragon_flight_advanced.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/snapdragon_flight_advanced.html';</script>
 </body></html>

--- a/en/flight_controller/snapdragon_flight_configuration.html
+++ b/en/flight_controller/snapdragon_flight_configuration.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/snapdragon_flight_configuration.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/snapdragon_flight_configuration.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/snapdragon_flight_configuration.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/snapdragon_flight_configuration.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/snapdragon_flight_configuration.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/snapdragon_flight_configuration.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/snapdragon_flight_configuration.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/snapdragon_flight_configuration.html';</script>
 </body></html>

--- a/en/flight_controller/snapdragon_flight_dev_environment_installation.html
+++ b/en/flight_controller/snapdragon_flight_dev_environment_installation.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/snapdragon_flight_dev_environment_installation.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/snapdragon_flight_dev_environment_installation.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/snapdragon_flight_dev_environment_installation.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/snapdragon_flight_dev_environment_installation.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/snapdragon_flight_dev_environment_installation.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/snapdragon_flight_dev_environment_installation.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/snapdragon_flight_dev_environment_installation.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/snapdragon_flight_dev_environment_installation.html';</script>
 </body></html>

--- a/en/flight_controller/snapdragon_flight_hardware_example_setup.html
+++ b/en/flight_controller/snapdragon_flight_hardware_example_setup.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/snapdragon_flight_hardware_example_setup.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/snapdragon_flight_hardware_example_setup.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/snapdragon_flight_hardware_example_setup.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/snapdragon_flight_hardware_example_setup.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/snapdragon_flight_hardware_example_setup.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/snapdragon_flight_hardware_example_setup.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/snapdragon_flight_hardware_example_setup.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/snapdragon_flight_hardware_example_setup.html';</script>
 </body></html>

--- a/en/flight_controller/snapdragon_flight_software_installation.html
+++ b/en/flight_controller/snapdragon_flight_software_installation.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_controller/snapdragon_flight_software_installation.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_controller/snapdragon_flight_software_installation.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_controller/snapdragon_flight_software_installation.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_controller/snapdragon_flight_software_installation.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_controller/snapdragon_flight_software_installation.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_controller/snapdragon_flight_software_installation.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_controller/snapdragon_flight_software_installation.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_controller/snapdragon_flight_software_installation.html';</script>
 </body></html>

--- a/en/flight_modes/acro_fw.html
+++ b/en/flight_modes/acro_fw.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/acro_fw.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/acro_fw.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/acro_fw.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/acro_fw.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/acro_fw.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/acro_fw.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/acro_fw.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/acro_fw.html';</script>
 </body></html>

--- a/en/flight_modes/acro_mc.html
+++ b/en/flight_modes/acro_mc.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/acro_mc.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/acro_mc.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/acro_mc.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/acro_mc.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/acro_mc.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/acro_mc.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/acro_mc.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/acro_mc.html';</script>
 </body></html>

--- a/en/flight_modes/altitude_fw.html
+++ b/en/flight_modes/altitude_fw.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/altitude_fw.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/altitude_fw.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/altitude_fw.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/altitude_fw.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/altitude_fw.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/altitude_fw.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/altitude_fw.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/altitude_fw.html';</script>
 </body></html>

--- a/en/flight_modes/altitude_mc.html
+++ b/en/flight_modes/altitude_mc.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/altitude_mc.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/altitude_mc.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/altitude_mc.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/altitude_mc.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/altitude_mc.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/altitude_mc.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/altitude_mc.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/altitude_mc.html';</script>
 </body></html>

--- a/en/flight_modes/follow_me.html
+++ b/en/flight_modes/follow_me.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/follow_me.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/follow_me.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/follow_me.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/follow_me.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/follow_me.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/follow_me.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/follow_me.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/follow_me.html';</script>
 </body></html>

--- a/en/flight_modes/hold.html
+++ b/en/flight_modes/hold.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/hold.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/hold.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/hold.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/hold.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/hold.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/hold.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/hold.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/hold.html';</script>
 </body></html>

--- a/en/flight_modes/index.html
+++ b/en/flight_modes/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/index.html';</script>
 </body></html>

--- a/en/flight_modes/land.html
+++ b/en/flight_modes/land.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/land.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/land.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/land.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/land.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/land.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/land.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/land.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/land.html';</script>
 </body></html>

--- a/en/flight_modes/manual_fw.html
+++ b/en/flight_modes/manual_fw.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/manual_fw.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/manual_fw.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/manual_fw.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/manual_fw.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/manual_fw.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/manual_fw.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/manual_fw.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/manual_fw.html';</script>
 </body></html>

--- a/en/flight_modes/manual_stabilized_mc.html
+++ b/en/flight_modes/manual_stabilized_mc.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/manual_stabilized_mc.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/manual_stabilized_mc.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/manual_stabilized_mc.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/manual_stabilized_mc.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/manual_stabilized_mc.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/manual_stabilized_mc.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/manual_stabilized_mc.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/manual_stabilized_mc.html';</script>
 </body></html>

--- a/en/flight_modes/mission.html
+++ b/en/flight_modes/mission.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/mission.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/mission.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/mission.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/mission.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/mission.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/mission.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/mission.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/mission.html';</script>
 </body></html>

--- a/en/flight_modes/offboard.html
+++ b/en/flight_modes/offboard.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/offboard.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/offboard.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/offboard.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/offboard.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/offboard.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/offboard.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/offboard.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/offboard.html';</script>
 </body></html>

--- a/en/flight_modes/orbit.html
+++ b/en/flight_modes/orbit.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/orbit.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/orbit.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/orbit.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/orbit.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/orbit.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/orbit.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/orbit.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/orbit.html';</script>
 </body></html>

--- a/en/flight_modes/position_fw.html
+++ b/en/flight_modes/position_fw.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/position_fw.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/position_fw.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/position_fw.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/position_fw.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/position_fw.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/position_fw.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/position_fw.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/position_fw.html';</script>
 </body></html>

--- a/en/flight_modes/position_mc.html
+++ b/en/flight_modes/position_mc.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/position_mc.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/position_mc.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/position_mc.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/position_mc.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/position_mc.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/position_mc.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/position_mc.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/position_mc.html';</script>
 </body></html>

--- a/en/flight_modes/rattitude_mc.html
+++ b/en/flight_modes/rattitude_mc.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/rattitude_mc.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/rattitude_mc.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/rattitude_mc.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/rattitude_mc.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/rattitude_mc.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/rattitude_mc.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/rattitude_mc.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/rattitude_mc.html';</script>
 </body></html>

--- a/en/flight_modes/return.html
+++ b/en/flight_modes/return.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/return.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/return.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/return.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/return.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/return.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/return.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/return.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/return.html';</script>
 </body></html>

--- a/en/flight_modes/stabilized_fw.html
+++ b/en/flight_modes/stabilized_fw.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/stabilized_fw.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/stabilized_fw.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/stabilized_fw.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/stabilized_fw.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/stabilized_fw.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/stabilized_fw.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/stabilized_fw.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/stabilized_fw.html';</script>
 </body></html>

--- a/en/flight_modes/takeoff.html
+++ b/en/flight_modes/takeoff.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flight_modes/takeoff.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flight_modes/takeoff.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flight_modes/takeoff.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flight_modes/takeoff.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flight_modes/takeoff.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flight_modes/takeoff.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flight_modes/takeoff.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flight_modes/takeoff.html';</script>
 </body></html>

--- a/en/flying/basic_flying.html
+++ b/en/flying/basic_flying.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flying/basic_flying.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flying/basic_flying.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flying/basic_flying.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flying/basic_flying.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flying/basic_flying.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flying/basic_flying.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flying/basic_flying.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flying/basic_flying.html';</script>
 </body></html>

--- a/en/flying/first_flight_guidelines.html
+++ b/en/flying/first_flight_guidelines.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flying/first_flight_guidelines.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flying/first_flight_guidelines.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flying/first_flight_guidelines.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flying/first_flight_guidelines.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flying/first_flight_guidelines.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flying/first_flight_guidelines.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flying/first_flight_guidelines.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flying/first_flight_guidelines.html';</script>
 </body></html>

--- a/en/flying/fixed_wing_landing.html
+++ b/en/flying/fixed_wing_landing.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flying/fixed_wing_landing.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flying/fixed_wing_landing.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flying/fixed_wing_landing.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flying/fixed_wing_landing.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flying/fixed_wing_landing.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flying/fixed_wing_landing.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flying/fixed_wing_landing.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flying/fixed_wing_landing.html';</script>
 </body></html>

--- a/en/flying/flight_reporting.html
+++ b/en/flying/flight_reporting.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flying/flight_reporting.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flying/flight_reporting.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flying/flight_reporting.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flying/flight_reporting.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flying/flight_reporting.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flying/flight_reporting.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flying/flight_reporting.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flying/flight_reporting.html';</script>
 </body></html>

--- a/en/flying/index.html
+++ b/en/flying/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flying/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flying/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flying/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flying/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flying/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flying/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flying/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flying/index.html';</script>
 </body></html>

--- a/en/flying/led_meanings.html
+++ b/en/flying/led_meanings.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flying/led_meanings.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flying/led_meanings.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flying/led_meanings.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flying/led_meanings.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flying/led_meanings.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flying/led_meanings.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flying/led_meanings.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flying/led_meanings.html';</script>
 </body></html>

--- a/en/flying/missions.html
+++ b/en/flying/missions.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flying/missions.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flying/missions.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flying/missions.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flying/missions.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flying/missions.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flying/missions.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flying/missions.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flying/missions.html';</script>
 </body></html>

--- a/en/flying/pre_flight_checks.html
+++ b/en/flying/pre_flight_checks.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flying/pre_flight_checks.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flying/pre_flight_checks.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flying/pre_flight_checks.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flying/pre_flight_checks.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flying/pre_flight_checks.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flying/pre_flight_checks.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flying/pre_flight_checks.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flying/pre_flight_checks.html';</script>
 </body></html>

--- a/en/flying/terrain_following_holding.html
+++ b/en/flying/terrain_following_holding.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/flying/terrain_following_holding.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/flying/terrain_following_holding.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/flying/terrain_following_holding.html'>
+<meta http-equiv=refresh content='0; url=/master/en/flying/terrain_following_holding.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/flying/terrain_following_holding.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/flying/terrain_following_holding.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/flying/terrain_following_holding.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/flying/terrain_following_holding.html';</script>
 </body></html>

--- a/en/framebuild_multicopter/lumenier_qav250_pixhawk_auav_x2.html
+++ b/en/framebuild_multicopter/lumenier_qav250_pixhawk_auav_x2.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/framebuild_multicopter/lumenier_qav250_pixhawk_auav_x2.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/framebuild_multicopter/lumenier_qav250_pixhawk_auav_x2.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/framebuild_multicopter/lumenier_qav250_pixhawk_auav_x2.html'>
+<meta http-equiv=refresh content='0; url=/master/en/framebuild_multicopter/lumenier_qav250_pixhawk_auav_x2.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/framebuild_multicopter/lumenier_qav250_pixhawk_auav_x2.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/framebuild_multicopter/lumenier_qav250_pixhawk_auav_x2.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/framebuild_multicopter/lumenier_qav250_pixhawk_auav_x2.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/framebuild_multicopter/lumenier_qav250_pixhawk_auav_x2.html';</script>
 </body></html>

--- a/en/framebuild_multicopter/lumenier_qav250_pixhawk_mini.html
+++ b/en/framebuild_multicopter/lumenier_qav250_pixhawk_mini.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/framebuild_multicopter/lumenier_qav250_pixhawk_mini.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/framebuild_multicopter/lumenier_qav250_pixhawk_mini.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/framebuild_multicopter/lumenier_qav250_pixhawk_mini.html'>
+<meta http-equiv=refresh content='0; url=/master/en/framebuild_multicopter/lumenier_qav250_pixhawk_mini.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/framebuild_multicopter/lumenier_qav250_pixhawk_mini.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/framebuild_multicopter/lumenier_qav250_pixhawk_mini.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/framebuild_multicopter/lumenier_qav250_pixhawk_mini.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/framebuild_multicopter/lumenier_qav250_pixhawk_mini.html';</script>
 </body></html>

--- a/en/framebuild_multicopter/robocat_270_pixracer.html
+++ b/en/framebuild_multicopter/robocat_270_pixracer.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/framebuild_multicopter/robocat_270_pixracer.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/framebuild_multicopter/robocat_270_pixracer.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/framebuild_multicopter/robocat_270_pixracer.html'>
+<meta http-equiv=refresh content='0; url=/master/en/framebuild_multicopter/robocat_270_pixracer.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/framebuild_multicopter/robocat_270_pixracer.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/framebuild_multicopter/robocat_270_pixracer.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/framebuild_multicopter/robocat_270_pixracer.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/framebuild_multicopter/robocat_270_pixracer.html';</script>
 </body></html>

--- a/en/framebuild_multicopter/spedix_s250_pixracer.html
+++ b/en/framebuild_multicopter/spedix_s250_pixracer.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/framebuild_multicopter/spedix_s250_pixracer.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/framebuild_multicopter/spedix_s250_pixracer.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/framebuild_multicopter/spedix_s250_pixracer.html'>
+<meta http-equiv=refresh content='0; url=/master/en/framebuild_multicopter/spedix_s250_pixracer.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/framebuild_multicopter/spedix_s250_pixracer.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/framebuild_multicopter/spedix_s250_pixracer.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/framebuild_multicopter/spedix_s250_pixracer.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/framebuild_multicopter/spedix_s250_pixracer.html';</script>
 </body></html>

--- a/en/framebuild_plane/wing_wing_z84.html
+++ b/en/framebuild_plane/wing_wing_z84.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/framebuild_plane/wing_wing_z84.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/framebuild_plane/wing_wing_z84.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/framebuild_plane/wing_wing_z84.html'>
+<meta http-equiv=refresh content='0; url=/master/en/framebuild_plane/wing_wing_z84.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/framebuild_plane/wing_wing_z84.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/framebuild_plane/wing_wing_z84.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/framebuild_plane/wing_wing_z84.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/framebuild_plane/wing_wing_z84.html';</script>
 </body></html>

--- a/en/framebuild_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html
+++ b/en/framebuild_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/framebuild_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/framebuild_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/framebuild_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html'>
+<meta http-equiv=refresh content='0; url=/master/en/framebuild_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/framebuild_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/framebuild_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/framebuild_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/framebuild_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html';</script>
 </body></html>

--- a/en/framebuild_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html
+++ b/en/framebuild_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/framebuild_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/framebuild_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/framebuild_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html'>
+<meta http-equiv=refresh content='0; url=/master/en/framebuild_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/framebuild_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/framebuild_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/framebuild_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/framebuild_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html';</script>
 </body></html>

--- a/en/framebuild_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html
+++ b/en/framebuild_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/framebuild_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/framebuild_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/framebuild_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html'>
+<meta http-equiv=refresh content='0; url=/master/en/framebuild_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/framebuild_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/framebuild_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/framebuild_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/framebuild_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html';</script>
 </body></html>

--- a/en/framebuild_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html
+++ b/en/framebuild_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/framebuild_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/framebuild_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/framebuild_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html'>
+<meta http-equiv=refresh content='0; url=/master/en/framebuild_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/framebuild_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/framebuild_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/framebuild_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/framebuild_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html';</script>
 </body></html>

--- a/en/framebuild_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html
+++ b/en/framebuild_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/framebuild_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/framebuild_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/framebuild_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html'>
+<meta http-equiv=refresh content='0; url=/master/en/framebuild_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/framebuild_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/framebuild_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/framebuild_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/framebuild_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html';</script>
 </body></html>

--- a/en/frames_multicopter/dji_flamewheel_450.html
+++ b/en/frames_multicopter/dji_flamewheel_450.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_multicopter/dji_flamewheel_450.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_multicopter/dji_flamewheel_450.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_multicopter/dji_flamewheel_450.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_multicopter/dji_flamewheel_450.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_multicopter/dji_flamewheel_450.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_multicopter/dji_flamewheel_450.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_multicopter/dji_flamewheel_450.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_multicopter/dji_flamewheel_450.html';</script>
 </body></html>

--- a/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html
+++ b/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html';</script>
 </body></html>

--- a/en/frames_multicopter/index.html
+++ b/en/frames_multicopter/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_multicopter/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_multicopter/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_multicopter/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_multicopter/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_multicopter/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_multicopter/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_multicopter/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_multicopter/index.html';</script>
 </body></html>

--- a/en/frames_multicopter/lumenier_qav250_pixhawk_auav_x2.html
+++ b/en/frames_multicopter/lumenier_qav250_pixhawk_auav_x2.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_multicopter/lumenier_qav250_pixhawk_auav_x2.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_multicopter/lumenier_qav250_pixhawk_auav_x2.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_multicopter/lumenier_qav250_pixhawk_auav_x2.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_multicopter/lumenier_qav250_pixhawk_auav_x2.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_multicopter/lumenier_qav250_pixhawk_auav_x2.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_multicopter/lumenier_qav250_pixhawk_auav_x2.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_multicopter/lumenier_qav250_pixhawk_auav_x2.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_multicopter/lumenier_qav250_pixhawk_auav_x2.html';</script>
 </body></html>

--- a/en/frames_multicopter/lumenier_qav250_pixhawk_mini.html
+++ b/en/frames_multicopter/lumenier_qav250_pixhawk_mini.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_multicopter/lumenier_qav250_pixhawk_mini.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_multicopter/lumenier_qav250_pixhawk_mini.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_multicopter/lumenier_qav250_pixhawk_mini.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_multicopter/lumenier_qav250_pixhawk_mini.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_multicopter/lumenier_qav250_pixhawk_mini.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_multicopter/lumenier_qav250_pixhawk_mini.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_multicopter/lumenier_qav250_pixhawk_mini.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_multicopter/lumenier_qav250_pixhawk_mini.html';</script>
 </body></html>

--- a/en/frames_multicopter/matrice100.html
+++ b/en/frames_multicopter/matrice100.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_multicopter/matrice100.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_multicopter/matrice100.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_multicopter/matrice100.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_multicopter/matrice100.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_multicopter/matrice100.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_multicopter/matrice100.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_multicopter/matrice100.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_multicopter/matrice100.html';</script>
 </body></html>

--- a/en/frames_multicopter/qav_r_5_kiss_esc_racer.html
+++ b/en/frames_multicopter/qav_r_5_kiss_esc_racer.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_multicopter/qav_r_5_kiss_esc_racer.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_multicopter/qav_r_5_kiss_esc_racer.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_multicopter/qav_r_5_kiss_esc_racer.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_multicopter/qav_r_5_kiss_esc_racer.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_multicopter/qav_r_5_kiss_esc_racer.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_multicopter/qav_r_5_kiss_esc_racer.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_multicopter/qav_r_5_kiss_esc_racer.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_multicopter/qav_r_5_kiss_esc_racer.html';</script>
 </body></html>

--- a/en/frames_multicopter/robocat_270_pixracer.html
+++ b/en/frames_multicopter/robocat_270_pixracer.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_multicopter/robocat_270_pixracer.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_multicopter/robocat_270_pixracer.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_multicopter/robocat_270_pixracer.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_multicopter/robocat_270_pixracer.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_multicopter/robocat_270_pixracer.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_multicopter/robocat_270_pixracer.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_multicopter/robocat_270_pixracer.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_multicopter/robocat_270_pixracer.html';</script>
 </body></html>

--- a/en/frames_multicopter/spedix_s250_pixracer.html
+++ b/en/frames_multicopter/spedix_s250_pixracer.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_multicopter/spedix_s250_pixracer.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_multicopter/spedix_s250_pixracer.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_multicopter/spedix_s250_pixracer.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_multicopter/spedix_s250_pixracer.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_multicopter/spedix_s250_pixracer.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_multicopter/spedix_s250_pixracer.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_multicopter/spedix_s250_pixracer.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_multicopter/spedix_s250_pixracer.html';</script>
 </body></html>

--- a/en/frames_plane/index.html
+++ b/en/frames_plane/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_plane/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_plane/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_plane/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_plane/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_plane/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_plane/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_plane/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_plane/index.html';</script>
 </body></html>

--- a/en/frames_plane/wing_wing_z84.html
+++ b/en/frames_plane/wing_wing_z84.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_plane/wing_wing_z84.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_plane/wing_wing_z84.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_plane/wing_wing_z84.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_plane/wing_wing_z84.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_plane/wing_wing_z84.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_plane/wing_wing_z84.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_plane/wing_wing_z84.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_plane/wing_wing_z84.html';</script>
 </body></html>

--- a/en/frames_rover/index.html
+++ b/en/frames_rover/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_rover/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_rover/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_rover/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_rover/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_rover/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_rover/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_rover/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_rover/index.html';</script>
 </body></html>

--- a/en/frames_rover/traxxas_stampede.html
+++ b/en/frames_rover/traxxas_stampede.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_rover/traxxas_stampede.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_rover/traxxas_stampede.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_rover/traxxas_stampede.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_rover/traxxas_stampede.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_rover/traxxas_stampede.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_rover/traxxas_stampede.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_rover/traxxas_stampede.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_rover/traxxas_stampede.html';</script>
 </body></html>

--- a/en/frames_vtol/index.html
+++ b/en/frames_vtol/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_vtol/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_vtol/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_vtol/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_vtol/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_vtol/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_vtol/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_vtol/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_vtol/index.html';</script>
 </body></html>

--- a/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html
+++ b/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.html';</script>
 </body></html>

--- a/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html
+++ b/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.html';</script>
 </body></html>

--- a/en/frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html
+++ b/en/frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.html';</script>
 </body></html>

--- a/en/frames_vtol/vtol_tailsitter_caipiroshka_pixracer.html
+++ b/en/frames_vtol/vtol_tailsitter_caipiroshka_pixracer.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_vtol/vtol_tailsitter_caipiroshka_pixracer.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_vtol/vtol_tailsitter_caipiroshka_pixracer.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_vtol/vtol_tailsitter_caipiroshka_pixracer.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_vtol/vtol_tailsitter_caipiroshka_pixracer.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_vtol/vtol_tailsitter_caipiroshka_pixracer.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_vtol/vtol_tailsitter_caipiroshka_pixracer.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_vtol/vtol_tailsitter_caipiroshka_pixracer.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_vtol/vtol_tailsitter_caipiroshka_pixracer.html';</script>
 </body></html>

--- a/en/frames_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html
+++ b/en/frames_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.html';</script>
 </body></html>

--- a/en/frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html
+++ b/en/frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html'>
+<meta http-equiv=refresh content='0; url=/master/en/frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.html';</script>
 </body></html>

--- a/en/getting_started/flight_controller_selection.html
+++ b/en/getting_started/flight_controller_selection.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/getting_started/flight_controller_selection.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/getting_started/flight_controller_selection.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/getting_started/flight_controller_selection.html'>
+<meta http-equiv=refresh content='0; url=/master/en/getting_started/flight_controller_selection.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/getting_started/flight_controller_selection.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/getting_started/flight_controller_selection.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/getting_started/flight_controller_selection.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/getting_started/flight_controller_selection.html';</script>
 </body></html>

--- a/en/getting_started/flight_modes.html
+++ b/en/getting_started/flight_modes.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/getting_started/flight_modes.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/getting_started/flight_modes.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/getting_started/flight_modes.html'>
+<meta http-equiv=refresh content='0; url=/master/en/getting_started/flight_modes.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/getting_started/flight_modes.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/getting_started/flight_modes.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/getting_started/flight_modes.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/getting_started/flight_modes.html';</script>
 </body></html>

--- a/en/getting_started/flight_reporting.html
+++ b/en/getting_started/flight_reporting.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/getting_started/flight_reporting.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/getting_started/flight_reporting.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/getting_started/flight_reporting.html'>
+<meta http-equiv=refresh content='0; url=/master/en/getting_started/flight_reporting.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/getting_started/flight_reporting.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/getting_started/flight_reporting.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/getting_started/flight_reporting.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/getting_started/flight_reporting.html';</script>
 </body></html>

--- a/en/getting_started/frame_selection.html
+++ b/en/getting_started/frame_selection.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/getting_started/frame_selection.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/getting_started/frame_selection.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/getting_started/frame_selection.html'>
+<meta http-equiv=refresh content='0; url=/master/en/getting_started/frame_selection.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/getting_started/frame_selection.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/getting_started/frame_selection.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/getting_started/frame_selection.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/getting_started/frame_selection.html';</script>
 </body></html>

--- a/en/getting_started/index.html
+++ b/en/getting_started/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/getting_started/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/getting_started/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/getting_started/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/getting_started/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/getting_started/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/getting_started/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/getting_started/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/getting_started/index.html';</script>
 </body></html>

--- a/en/getting_started/led_meanings.html
+++ b/en/getting_started/led_meanings.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/getting_started/led_meanings.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/getting_started/led_meanings.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/getting_started/led_meanings.html'>
+<meta http-equiv=refresh content='0; url=/master/en/getting_started/led_meanings.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/getting_started/led_meanings.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/getting_started/led_meanings.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/getting_started/led_meanings.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/getting_started/led_meanings.html';</script>
 </body></html>

--- a/en/getting_started/px4_basic_concepts.html
+++ b/en/getting_started/px4_basic_concepts.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/getting_started/px4_basic_concepts.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/getting_started/px4_basic_concepts.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/getting_started/px4_basic_concepts.html'>
+<meta http-equiv=refresh content='0; url=/master/en/getting_started/px4_basic_concepts.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/getting_started/px4_basic_concepts.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/getting_started/px4_basic_concepts.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/getting_started/px4_basic_concepts.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/getting_started/px4_basic_concepts.html';</script>
 </body></html>

--- a/en/getting_started/rc_transmitter_receiver.html
+++ b/en/getting_started/rc_transmitter_receiver.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/getting_started/rc_transmitter_receiver.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/getting_started/rc_transmitter_receiver.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/getting_started/rc_transmitter_receiver.html'>
+<meta http-equiv=refresh content='0; url=/master/en/getting_started/rc_transmitter_receiver.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/getting_started/rc_transmitter_receiver.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/getting_started/rc_transmitter_receiver.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/getting_started/rc_transmitter_receiver.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/getting_started/rc_transmitter_receiver.html';</script>
 </body></html>

--- a/en/getting_started/sensor_selection.html
+++ b/en/getting_started/sensor_selection.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/getting_started/sensor_selection.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/getting_started/sensor_selection.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/getting_started/sensor_selection.html'>
+<meta http-equiv=refresh content='0; url=/master/en/getting_started/sensor_selection.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/getting_started/sensor_selection.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/getting_started/sensor_selection.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/getting_started/sensor_selection.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/getting_started/sensor_selection.html';</script>
 </body></html>

--- a/en/getting_started/tunes.html
+++ b/en/getting_started/tunes.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/getting_started/tunes.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/getting_started/tunes.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/getting_started/tunes.html'>
+<meta http-equiv=refresh content='0; url=/master/en/getting_started/tunes.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/getting_started/tunes.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/getting_started/tunes.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/getting_started/tunes.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/getting_started/tunes.html';</script>
 </body></html>

--- a/en/getting_started/vehicle_status.html
+++ b/en/getting_started/vehicle_status.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/getting_started/vehicle_status.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/getting_started/vehicle_status.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/getting_started/vehicle_status.html'>
+<meta http-equiv=refresh content='0; url=/master/en/getting_started/vehicle_status.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/getting_started/vehicle_status.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/getting_started/vehicle_status.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/getting_started/vehicle_status.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/getting_started/vehicle_status.html';</script>
 </body></html>

--- a/en/gps_compass/index.html
+++ b/en/gps_compass/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/gps_compass/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/gps_compass/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/gps_compass/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/gps_compass/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/gps_compass/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/gps_compass/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/gps_compass/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/gps_compass/index.html';</script>
 </body></html>

--- a/en/gps_compass/rtk_gps.html
+++ b/en/gps_compass/rtk_gps.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/gps_compass/rtk_gps.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/gps_compass/rtk_gps.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/gps_compass/rtk_gps.html'>
+<meta http-equiv=refresh content='0; url=/master/en/gps_compass/rtk_gps.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/gps_compass/rtk_gps.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/gps_compass/rtk_gps.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/gps_compass/rtk_gps.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/gps_compass/rtk_gps.html';</script>
 </body></html>

--- a/en/gps_compass/rtk_gps_cuav_c-rtk.html
+++ b/en/gps_compass/rtk_gps_cuav_c-rtk.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/gps_compass/rtk_gps_cuav_c-rtk.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/gps_compass/rtk_gps_cuav_c-rtk.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/gps_compass/rtk_gps_cuav_c-rtk.html'>
+<meta http-equiv=refresh content='0; url=/master/en/gps_compass/rtk_gps_cuav_c-rtk.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/gps_compass/rtk_gps_cuav_c-rtk.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/gps_compass/rtk_gps_cuav_c-rtk.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/gps_compass/rtk_gps_cuav_c-rtk.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/gps_compass/rtk_gps_cuav_c-rtk.html';</script>
 </body></html>

--- a/en/gps_compass/rtk_gps_drotek_xl.html
+++ b/en/gps_compass/rtk_gps_drotek_xl.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/gps_compass/rtk_gps_drotek_xl.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/gps_compass/rtk_gps_drotek_xl.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/gps_compass/rtk_gps_drotek_xl.html'>
+<meta http-equiv=refresh content='0; url=/master/en/gps_compass/rtk_gps_drotek_xl.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/gps_compass/rtk_gps_drotek_xl.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/gps_compass/rtk_gps_drotek_xl.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/gps_compass/rtk_gps_drotek_xl.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/gps_compass/rtk_gps_drotek_xl.html';</script>
 </body></html>

--- a/en/gps_compass/rtk_gps_hex_hereplus.html
+++ b/en/gps_compass/rtk_gps_hex_hereplus.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/gps_compass/rtk_gps_hex_hereplus.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/gps_compass/rtk_gps_hex_hereplus.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/gps_compass/rtk_gps_hex_hereplus.html'>
+<meta http-equiv=refresh content='0; url=/master/en/gps_compass/rtk_gps_hex_hereplus.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/gps_compass/rtk_gps_hex_hereplus.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/gps_compass/rtk_gps_hex_hereplus.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/gps_compass/rtk_gps_hex_hereplus.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/gps_compass/rtk_gps_hex_hereplus.html';</script>
 </body></html>

--- a/en/gps_compass/rtk_gps_trimble_mb_two.html
+++ b/en/gps_compass/rtk_gps_trimble_mb_two.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/gps_compass/rtk_gps_trimble_mb_two.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/gps_compass/rtk_gps_trimble_mb_two.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/gps_compass/rtk_gps_trimble_mb_two.html'>
+<meta http-equiv=refresh content='0; url=/master/en/gps_compass/rtk_gps_trimble_mb_two.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/gps_compass/rtk_gps_trimble_mb_two.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/gps_compass/rtk_gps_trimble_mb_two.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/gps_compass/rtk_gps_trimble_mb_two.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/gps_compass/rtk_gps_trimble_mb_two.html';</script>
 </body></html>

--- a/en/index.html
+++ b/en/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to latest version of documents (master)</title>
+<title>Redirecting to latest version of document (master)</title>
 <link rel='canonical' href='/master/en/index.html'>
-<meta http-equiv=refresh content='0; url=/master/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/index.html'>
 </head>
 <body>
-<h1>Redirecting to latest version of documents</h1>
+<h1>Redirecting to latest version of document</h1>
 <p><a href='/master/en/index.html'>Click here if you are not redirected</a></p>
 <script>window.location.href='/master/en/index.html';</script>
 </body></html>

--- a/en/log/flight_log_analysis.html
+++ b/en/log/flight_log_analysis.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/log/flight_log_analysis.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/log/flight_log_analysis.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/log/flight_log_analysis.html'>
+<meta http-equiv=refresh content='0; url=/master/en/log/flight_log_analysis.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/log/flight_log_analysis.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/log/flight_log_analysis.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/log/flight_log_analysis.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/log/flight_log_analysis.html';</script>
 </body></html>

--- a/en/log/flight_review.html
+++ b/en/log/flight_review.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/log/flight_review.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/log/flight_review.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/log/flight_review.html'>
+<meta http-equiv=refresh content='0; url=/master/en/log/flight_review.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/log/flight_review.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/log/flight_review.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/log/flight_review.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/log/flight_review.html';</script>
 </body></html>

--- a/en/peripherals/camera.html
+++ b/en/peripherals/camera.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/peripherals/camera.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/peripherals/camera.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/peripherals/camera.html'>
+<meta http-equiv=refresh content='0; url=/master/en/peripherals/camera.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/peripherals/camera.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/peripherals/camera.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/peripherals/camera.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/peripherals/camera.html';</script>
 </body></html>

--- a/en/peripherals/companion_computer_peripherals.html
+++ b/en/peripherals/companion_computer_peripherals.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/peripherals/companion_computer_peripherals.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/peripherals/companion_computer_peripherals.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/peripherals/companion_computer_peripherals.html'>
+<meta http-equiv=refresh content='0; url=/master/en/peripherals/companion_computer_peripherals.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/peripherals/companion_computer_peripherals.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/peripherals/companion_computer_peripherals.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/peripherals/companion_computer_peripherals.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/peripherals/companion_computer_peripherals.html';</script>
 </body></html>

--- a/en/peripherals/esc_motors.html
+++ b/en/peripherals/esc_motors.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/peripherals/esc_motors.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/peripherals/esc_motors.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/peripherals/esc_motors.html'>
+<meta http-equiv=refresh content='0; url=/master/en/peripherals/esc_motors.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/peripherals/esc_motors.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/peripherals/esc_motors.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/peripherals/esc_motors.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/peripherals/esc_motors.html';</script>
 </body></html>

--- a/en/peripherals/frsky_telemetry.html
+++ b/en/peripherals/frsky_telemetry.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/peripherals/frsky_telemetry.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/peripherals/frsky_telemetry.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/peripherals/frsky_telemetry.html'>
+<meta http-equiv=refresh content='0; url=/master/en/peripherals/frsky_telemetry.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/peripherals/frsky_telemetry.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/peripherals/frsky_telemetry.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/peripherals/frsky_telemetry.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/peripherals/frsky_telemetry.html';</script>
 </body></html>

--- a/en/peripherals/index.html
+++ b/en/peripherals/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/peripherals/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/peripherals/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/peripherals/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/peripherals/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/peripherals/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/peripherals/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/peripherals/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/peripherals/index.html';</script>
 </body></html>

--- a/en/peripherals/mavlink_peripherals.html
+++ b/en/peripherals/mavlink_peripherals.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/peripherals/mavlink_peripherals.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/peripherals/mavlink_peripherals.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/peripherals/mavlink_peripherals.html'>
+<meta http-equiv=refresh content='0; url=/master/en/peripherals/mavlink_peripherals.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/peripherals/mavlink_peripherals.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/peripherals/mavlink_peripherals.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/peripherals/mavlink_peripherals.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/peripherals/mavlink_peripherals.html';</script>
 </body></html>

--- a/en/peripherals/pwm_escs_and_servo.html
+++ b/en/peripherals/pwm_escs_and_servo.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/peripherals/pwm_escs_and_servo.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/peripherals/pwm_escs_and_servo.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/peripherals/pwm_escs_and_servo.html'>
+<meta http-equiv=refresh content='0; url=/master/en/peripherals/pwm_escs_and_servo.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/peripherals/pwm_escs_and_servo.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/peripherals/pwm_escs_and_servo.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/peripherals/pwm_escs_and_servo.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/peripherals/pwm_escs_and_servo.html';</script>
 </body></html>

--- a/en/peripherals/rtk_gps_cuav_c-rtk.html
+++ b/en/peripherals/rtk_gps_cuav_c-rtk.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/peripherals/rtk_gps_cuav_c-rtk.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/peripherals/rtk_gps_cuav_c-rtk.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/peripherals/rtk_gps_cuav_c-rtk.html'>
+<meta http-equiv=refresh content='0; url=/master/en/peripherals/rtk_gps_cuav_c-rtk.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/peripherals/rtk_gps_cuav_c-rtk.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/peripherals/rtk_gps_cuav_c-rtk.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/peripherals/rtk_gps_cuav_c-rtk.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/peripherals/rtk_gps_cuav_c-rtk.html';</script>
 </body></html>

--- a/en/peripherals/rtk_gps_drotek_xl.html
+++ b/en/peripherals/rtk_gps_drotek_xl.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/peripherals/rtk_gps_drotek_xl.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/peripherals/rtk_gps_drotek_xl.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/peripherals/rtk_gps_drotek_xl.html'>
+<meta http-equiv=refresh content='0; url=/master/en/peripherals/rtk_gps_drotek_xl.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/peripherals/rtk_gps_drotek_xl.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/peripherals/rtk_gps_drotek_xl.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/peripherals/rtk_gps_drotek_xl.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/peripherals/rtk_gps_drotek_xl.html';</script>
 </body></html>

--- a/en/peripherals/rtk_gps_hex_hereplus.html
+++ b/en/peripherals/rtk_gps_hex_hereplus.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/peripherals/rtk_gps_hex_hereplus.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/peripherals/rtk_gps_hex_hereplus.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/peripherals/rtk_gps_hex_hereplus.html'>
+<meta http-equiv=refresh content='0; url=/master/en/peripherals/rtk_gps_hex_hereplus.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/peripherals/rtk_gps_hex_hereplus.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/peripherals/rtk_gps_hex_hereplus.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/peripherals/rtk_gps_hex_hereplus.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/peripherals/rtk_gps_hex_hereplus.html';</script>
 </body></html>

--- a/en/peripherals/serial_configuration.html
+++ b/en/peripherals/serial_configuration.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/peripherals/serial_configuration.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/peripherals/serial_configuration.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/peripherals/serial_configuration.html'>
+<meta http-equiv=refresh content='0; url=/master/en/peripherals/serial_configuration.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/peripherals/serial_configuration.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/peripherals/serial_configuration.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/peripherals/serial_configuration.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/peripherals/serial_configuration.html';</script>
 </body></html>

--- a/en/sensor/airspeed.html
+++ b/en/sensor/airspeed.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/sensor/airspeed.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/sensor/airspeed.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/sensor/airspeed.html'>
+<meta http-equiv=refresh content='0; url=/master/en/sensor/airspeed.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/sensor/airspeed.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/sensor/airspeed.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/sensor/airspeed.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/sensor/airspeed.html';</script>
 </body></html>

--- a/en/sensor/cm8jl65_ir_distance_sensor.html
+++ b/en/sensor/cm8jl65_ir_distance_sensor.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/sensor/cm8jl65_ir_distance_sensor.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/sensor/cm8jl65_ir_distance_sensor.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/sensor/cm8jl65_ir_distance_sensor.html'>
+<meta http-equiv=refresh content='0; url=/master/en/sensor/cm8jl65_ir_distance_sensor.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/sensor/cm8jl65_ir_distance_sensor.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/sensor/cm8jl65_ir_distance_sensor.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/sensor/cm8jl65_ir_distance_sensor.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/sensor/cm8jl65_ir_distance_sensor.html';</script>
 </body></html>

--- a/en/sensor/leddar_one.html
+++ b/en/sensor/leddar_one.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/sensor/leddar_one.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/sensor/leddar_one.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/sensor/leddar_one.html'>
+<meta http-equiv=refresh content='0; url=/master/en/sensor/leddar_one.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/sensor/leddar_one.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/sensor/leddar_one.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/sensor/leddar_one.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/sensor/leddar_one.html';</script>
 </body></html>

--- a/en/sensor/lidar_lite.html
+++ b/en/sensor/lidar_lite.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/sensor/lidar_lite.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/sensor/lidar_lite.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/sensor/lidar_lite.html'>
+<meta http-equiv=refresh content='0; url=/master/en/sensor/lidar_lite.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/sensor/lidar_lite.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/sensor/lidar_lite.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/sensor/lidar_lite.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/sensor/lidar_lite.html';</script>
 </body></html>

--- a/en/sensor/optical_flow.html
+++ b/en/sensor/optical_flow.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/sensor/optical_flow.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/sensor/optical_flow.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/sensor/optical_flow.html'>
+<meta http-equiv=refresh content='0; url=/master/en/sensor/optical_flow.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/sensor/optical_flow.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/sensor/optical_flow.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/sensor/optical_flow.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/sensor/optical_flow.html';</script>
 </body></html>

--- a/en/sensor/px4flow.html
+++ b/en/sensor/px4flow.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/sensor/px4flow.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/sensor/px4flow.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/sensor/px4flow.html'>
+<meta http-equiv=refresh content='0; url=/master/en/sensor/px4flow.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/sensor/px4flow.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/sensor/px4flow.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/sensor/px4flow.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/sensor/px4flow.html';</script>
 </body></html>

--- a/en/sensor/rangefinders.html
+++ b/en/sensor/rangefinders.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/sensor/rangefinders.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/sensor/rangefinders.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/sensor/rangefinders.html'>
+<meta http-equiv=refresh content='0; url=/master/en/sensor/rangefinders.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/sensor/rangefinders.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/sensor/rangefinders.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/sensor/rangefinders.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/sensor/rangefinders.html';</script>
 </body></html>

--- a/en/sensor/sfxx_lidar.html
+++ b/en/sensor/sfxx_lidar.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/sensor/sfxx_lidar.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/sensor/sfxx_lidar.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/sensor/sfxx_lidar.html'>
+<meta http-equiv=refresh content='0; url=/master/en/sensor/sfxx_lidar.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/sensor/sfxx_lidar.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/sensor/sfxx_lidar.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/sensor/sfxx_lidar.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/sensor/sfxx_lidar.html';</script>
 </body></html>

--- a/en/sensor/teraranger.html
+++ b/en/sensor/teraranger.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/sensor/teraranger.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/sensor/teraranger.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/sensor/teraranger.html'>
+<meta http-equiv=refresh content='0; url=/master/en/sensor/teraranger.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/sensor/teraranger.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/sensor/teraranger.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/sensor/teraranger.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/sensor/teraranger.html';</script>
 </body></html>

--- a/en/sensor/tfmini.html
+++ b/en/sensor/tfmini.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/sensor/tfmini.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/sensor/tfmini.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/sensor/tfmini.html'>
+<meta http-equiv=refresh content='0; url=/master/en/sensor/tfmini.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/sensor/tfmini.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/sensor/tfmini.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/sensor/tfmini.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/sensor/tfmini.html';</script>
 </body></html>

--- a/en/sensor/ulanding_radar.html
+++ b/en/sensor/ulanding_radar.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/sensor/ulanding_radar.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/sensor/ulanding_radar.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/sensor/ulanding_radar.html'>
+<meta http-equiv=refresh content='0; url=/master/en/sensor/ulanding_radar.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/sensor/ulanding_radar.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/sensor/ulanding_radar.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/sensor/ulanding_radar.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/sensor/ulanding_radar.html';</script>
 </body></html>

--- a/en/telemetry/3dr_telemetry_wifi.html
+++ b/en/telemetry/3dr_telemetry_wifi.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/telemetry/3dr_telemetry_wifi.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/telemetry/3dr_telemetry_wifi.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/telemetry/3dr_telemetry_wifi.html'>
+<meta http-equiv=refresh content='0; url=/master/en/telemetry/3dr_telemetry_wifi.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/telemetry/3dr_telemetry_wifi.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/telemetry/3dr_telemetry_wifi.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/telemetry/3dr_telemetry_wifi.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/telemetry/3dr_telemetry_wifi.html';</script>
 </body></html>

--- a/en/telemetry/esp8266_wifi_module.html
+++ b/en/telemetry/esp8266_wifi_module.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/telemetry/esp8266_wifi_module.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/telemetry/esp8266_wifi_module.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/telemetry/esp8266_wifi_module.html'>
+<meta http-equiv=refresh content='0; url=/master/en/telemetry/esp8266_wifi_module.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/telemetry/esp8266_wifi_module.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/telemetry/esp8266_wifi_module.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/telemetry/esp8266_wifi_module.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/telemetry/esp8266_wifi_module.html';</script>
 </body></html>

--- a/en/telemetry/hkpilot_sik_radio.html
+++ b/en/telemetry/hkpilot_sik_radio.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/telemetry/hkpilot_sik_radio.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/telemetry/hkpilot_sik_radio.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/telemetry/hkpilot_sik_radio.html'>
+<meta http-equiv=refresh content='0; url=/master/en/telemetry/hkpilot_sik_radio.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/telemetry/hkpilot_sik_radio.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/telemetry/hkpilot_sik_radio.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/telemetry/hkpilot_sik_radio.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/telemetry/hkpilot_sik_radio.html';</script>
 </body></html>

--- a/en/telemetry/holybro_sik_radio.html
+++ b/en/telemetry/holybro_sik_radio.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/telemetry/holybro_sik_radio.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/telemetry/holybro_sik_radio.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/telemetry/holybro_sik_radio.html'>
+<meta http-equiv=refresh content='0; url=/master/en/telemetry/holybro_sik_radio.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/telemetry/holybro_sik_radio.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/telemetry/holybro_sik_radio.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/telemetry/holybro_sik_radio.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/telemetry/holybro_sik_radio.html';</script>
 </body></html>

--- a/en/telemetry/index.html
+++ b/en/telemetry/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/telemetry/index.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/telemetry/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/telemetry/index.html'>
+<meta http-equiv=refresh content='0; url=/master/en/telemetry/index.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/telemetry/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/telemetry/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/telemetry/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/telemetry/index.html';</script>
 </body></html>

--- a/en/telemetry/rfd900_telemetry.html
+++ b/en/telemetry/rfd900_telemetry.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/telemetry/rfd900_telemetry.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/telemetry/rfd900_telemetry.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/telemetry/rfd900_telemetry.html'>
+<meta http-equiv=refresh content='0; url=/master/en/telemetry/rfd900_telemetry.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/telemetry/rfd900_telemetry.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/telemetry/rfd900_telemetry.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/telemetry/rfd900_telemetry.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/telemetry/rfd900_telemetry.html';</script>
 </body></html>

--- a/en/telemetry/sik_radio.html
+++ b/en/telemetry/sik_radio.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/telemetry/sik_radio.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/telemetry/sik_radio.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/telemetry/sik_radio.html'>
+<meta http-equiv=refresh content='0; url=/master/en/telemetry/sik_radio.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/telemetry/sik_radio.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/telemetry/sik_radio.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/telemetry/sik_radio.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/telemetry/sik_radio.html';</script>
 </body></html>

--- a/en/telemetry/telemetry_wifi.html
+++ b/en/telemetry/telemetry_wifi.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to v1.9 version of document</title>
-<link rel='canonical' href='/v1.9.0/en/telemetry/telemetry_wifi.html'>
-<meta http-equiv=refresh content='0; url=/v1.9.0/en/telemetry/telemetry_wifi.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/en/telemetry/telemetry_wifi.html'>
+<meta http-equiv=refresh content='0; url=/master/en/telemetry/telemetry_wifi.html'>
 </head>
 <body>
-<h1>Redirecting to v1.9 version of document</h1>
-<p><a href='/v1.9.0/en/telemetry/telemetry_wifi.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/v1.9.0/en/telemetry/telemetry_wifi.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/en/telemetry/telemetry_wifi.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/en/telemetry/telemetry_wifi.html';</script>
 </body></html>

--- a/index.html
+++ b/index.html
@@ -1,14 +1,13 @@
-
 <!DOCTYPE HTML>
 <html data-proofer-ignore>
 <head>
 <meta charset='UTF-8'>
-<title>Redirecting to latest version of documents (master)</title>
-<link rel='canonical' href='/master/en/index.html'>
+<title>Redirecting to latest version of document (master)</title>
+<link rel='canonical' href='/master/index.html'>
 <meta http-equiv=refresh content='0; url=/master/index.html'>
 </head>
 <body>
-<h1>Redirecting to latest version of documents</h1>
-<p><a href='/master/en/index.html'>Click here if you are not redirected</a></p>
-<script>window.location.href='/master/en/index.html';</script>
+<h1>Redirecting to latest version of document</h1>
+<p><a href='/master/index.html'>Click here if you are not redirected</a></p>
+<script>window.location.href='/master/index.html';</script>
 </body></html>


### PR DESCRIPTION
These were pointing to 1.9, which was stable version at point we moved to versions. The problem is that the search algorithms see all these links and priortise this as "latest version". Better to have master as the redirect than have an old version be found in search.